### PR TITLE
Fix dynamic value for host in ingress

### DIFF
--- a/ingress.tf
+++ b/ingress.tf
@@ -12,7 +12,7 @@ resource "kubernetes_ingress" "ingress" {
       }]
 
       content {
-        host = rule.host
+        host = rule.value.host
         http {
           path {
             path = var.ingress_path


### PR DESCRIPTION
Replace `host = rule.host` by `host = rule.value.host` in ingress.tf to fix error while creating Ingress.