### PR TITLE
Fix gun_prefixes array parsing and optional TLS in Ingress

### DIFF
--- a/configmaps.tf
+++ b/configmaps.tf
@@ -54,7 +54,7 @@ resource "kubernetes_config_map" "notary_config" {
       caching_enabled = var.caching_enabled,
       caching_current_metadata = var.caching_current_metadata,
       caching_consistent_metadata = var.caching_consistent_metadata,
-      gun_prefixes = join(",", var.gun_prefixes),
+      gun_prefixes = jsonencode(var.gun_prefixes),
     })
     "signer-config.json" = templatefile("${path.module}/templates/signer-config.json.tmpl", {
       signer_port = var.signer_port,

--- a/ingress.tf
+++ b/ingress.tf
@@ -24,9 +24,12 @@ resource "kubernetes_ingress" "ingress" {
         }
       }
     }
-    tls {
-      hosts = var.ingress_tls_hosts
-      secret_name = var.ingress_tls_secret_name
+    dynamic "tls" {
+      for_each = var.ingress_tls_hosts
+      content {
+        hosts = var.ingress_tls_hosts
+        secret_name = var.ingress_tls_secret_name
+      }
     }
   }
 }

--- a/templates/server-config.json.tmpl
+++ b/templates/server-config.json.tmpl
@@ -37,6 +37,6 @@
   },
   %{endif ~}
   "repositories": {
-    "gun_prefixes": ["${gun_prefixes}"]
+    "gun_prefixes": ${gun_prefixes}
   }
 }


### PR DESCRIPTION
### `gun_prefixes` array parsing
For instance, defining `gun_prefixes` in notary module's attributes like 
`gun_prefixes = ["<my_registry_1>/", "<my_registry_2>/"]` would be converted in ConfigMap in `gun_prefixes = ["<my_registry_1>/, <my_registry_2>/"]` (one single string) instead of `gun_prefixes = ["<my_registry_1>/", "<my_registry_2>/"]`

### Optional TLS Ingress
Even if `ingress_tls_hosts` is not defined in notary module's attributes, an Ingress `tls {}` block is created (and Terraform plan will always show a change, which is not convenient).
This block is optionnal in [kubernetes_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress#tls) resource.


